### PR TITLE
planes: corrige enlaces de materias 2009 y 2023

### DIFF
--- a/planes/2009.md
+++ b/planes/2009.md
@@ -1,40 +1,40 @@
 # Plan 2009 — Orden de cursada (LSI UNNE)
 
 ## 1° año
-- Algoritmos y Estructuras de Datos I — [materia](../Materias/Algoritmo y Estructura de datos 1/)
-- Álgebra — _(pendiente crear carpeta en Materias/)_
-- Algoritmos y Estructuras de Datos II — [materia](../Materias/Algoritmo y Estructura de datos 2/)
-- Lógica y Matemática Computacional — [materia](../Materias/Logica y Matematica Computacional/)
-- Sistemas y Organizaciones — [materia](../Materias/Sistemas y Organizaciones/)
+- Algoritmos y Estructuras de Datos I — [materia](../Materias/Algoritmo%20y%20Estructura%20de%20datos%201/)
+- Álgebra — no la curse tdv
+- Algoritmos y Estructuras de Datos II — [materia](../Materias/Algoritmo%20y%20Estructura%20de%20datos%202/)
+- Lógica y Matemática Computacional — [materia](../Materias/Logica%20y%20Matematica%20Computacional/)
+- Sistemas y Organizaciones — [materia](../Materias/Sistemas%20y%20Organizaciones/)
 
 ## 2° año
-- Paradigmas y Lenguajes — [materia](../Materias/Paradigmas y Lenguajes/)
-- Arquitectura y Organización de Computadoras — [materia](../Materias/Arquitectura de computadoras/)
+- Paradigmas y Lenguajes — [materia](../Materias/Paradigmas%20y%20Lenguajes/)
+- Arquitectura y Organización de Computadoras — [materia](../Materias/Arquitectura%20de%20computadoras/)
 - Cálculo Diferencial e Integral — [materia](../Materias/Calculo/)
-- Programación Orientada a Objetos — [materia](../Materias/Programacion Orientada a Objetos/)
-- Sistemas Operativos — [materia](../Materias/Sistemas Operativos/)
-- Administración y Gestión de Organizaciones — _(pendiente crear carpeta en Materias/)_
+- Programación Orientada a Objetos — [materia](../Materias/Programacion%20Orientada%20a%20Objetos/)
+- Sistemas Operativos — [materia](../Materias/Sistemas%20Operativos/)
+- Administración y Gestión de Organizaciones — [materia](../Materias/Administracion%20y%20Gestion%20de%20Organizaciones/)
 
 ## 3° año
-- Taller de Programación I — [materia](../Materias/Taller de Programacion 1/)
-- Comunicaciones de Datos — [materia](../Materias/Comunicacion de datos 1/)
-- Ingeniería de Software I — [materia](../Materias/Ingenieria de Software 1/)
-- Taller de Programación II — [materia](../Materias/Taller de Programacion 2/)
-- Probabilidad y Estadística — _(pendiente crear carpeta en Materias/)_
-- Bases de Datos I — _(pendiente crear carpeta en Materias/)_
-- Inglés Técnico Informático (exigencia extracurricular para APU) — _(info)_
+- Taller de Programación I — [materia](../Materias/Taller%20de%20Programacion%201/)
+- Comunicaciones de Datos — [materia](../Materias/Comunicacion%20de%20datos%201/)
+- Ingeniería de Software I — [materia](../Materias/Ingenieria%20de%20Software%201/)
+- Taller de Programación II — [materia](../Materias/Taller%20de%20Programacion%202/)
+- Probabilidad y Estadística — no la curse tdv
+- Bases de Datos I — no la curse tdv
+- Inglés Técnico Informático (exigencia extracurricular para APU) — no la curse tdv
 
 ## 4° año
-- Ingeniería de Software II — _(pendiente crear carpeta en Materias/)_
-- Economía Aplicada — _(pendiente crear carpeta en Materias/)_
-- Teoría de la Computación — _(pendiente crear carpeta en Materias/)_
-- Redes de Datos — _(pendiente crear carpeta en Materias/)_
-- Bases de Datos II — _(pendiente crear carpeta en Materias/)_
-- Métodos Computacionales — _(pendiente crear carpeta en Materias/)_
+- Ingeniería de Software II — no la curse tdv
+- Economía Aplicada — no la curse tdv
+- Teoría de la Computación — no la curse tdv
+- Redes de Datos — no la curse tdv
+- Bases de Datos II — no la curse tdv
+- Métodos Computacionales — no la curse tdv
 
 ## 5° año
-- Proyecto Final de Carrera (anual) — _(pendiente crear carpeta en Materias/)_
-- Auditoría y Seguridad Informática — _(pendiente crear carpeta en Materias/)_
-- Optativa I — _(pendiente crear carpeta en Materias/)_
-- Optativa II — _(pendiente crear carpeta en Materias/)_
-- Optativa III — _(pendiente crear carpeta en Materias/)_
+- Proyecto Final de Carrera (anual) — no la curse tdv
+- Auditoría y Seguridad Informática — no la curse tdv
+- Optativa I — no la curse tdv
+- Optativa II — no la curse tdv
+- Optativa III — no la curse tdv

--- a/planes/2023.md
+++ b/planes/2023.md
@@ -1,44 +1,44 @@
 # Plan 2023 — Orden de cursada (LSI UNNE)
 
 ## 1° año
-- Algoritmos y Estructuras de Datos I — [materia](../materias/algoritmos-estructuras-i/)
-- Álgebra — [materia](../materias/algebra/)
-- Algoritmos y Estructuras de Datos II — [materia](../materias/algoritmos-estructuras-ii/)
-- Lógica y Matemática Computacional — [materia](../materias/logica-matematica-computacional/)
-- Sistemas y Organizaciones — [materia](../materias/sistemas-y-organizaciones/)
+- Algoritmos y Estructuras de Datos I — [materia](../Materias/Algoritmo%20y%20Estructura%20de%20datos%201/)
+- Álgebra — no la curse tdv
+- Algoritmos y Estructuras de Datos II — [materia](../Materias/Algoritmo%20y%20Estructura%20de%20datos%202/)
+- Lógica y Matemática Computacional — [materia](../Materias/Logica%20y%20Matematica%20Computacional/)
+- Sistemas y Organizaciones — [materia](../Materias/Sistemas%20y%20Organizaciones/)
 
 ## 2° año
-- Paradigmas y Lenguajes — [materia](../materias/paradigmas-y-lenguajes/)
-- Arquitectura y Organización de Computadoras — [materia](../materias/arquitectura-y-organizacion-de-computadoras/)
-- Cálculo Diferencial e Integral — [materia](../materias/calculo-diferencial-e-integral/)
-- Programación Orientada a Objetos — [materia](../materias/poo/)
-- Sistemas Operativos — [materia](../materias/sistemas-operativos/)
-- Bases de Datos I — [materia](../materias/base-de-datos-i/)
+- Paradigmas y Lenguajes — [materia](../Materias/Paradigmas%20y%20Lenguajes/)
+- Arquitectura y Organización de Computadoras — [materia](../Materias/Arquitectura%20de%20computadoras/)
+- Cálculo Diferencial e Integral — [materia](../Materias/Calculo/)
+- Programación Orientada a Objetos — [materia](../Materias/Programacion%20Orientada%20a%20Objetos/)
+- Sistemas Operativos — [materia](../Materias/Sistemas%20Operativos/)
+- Bases de Datos I — no la curse tdv
 
 ## 3° año
-- Programación Web — [materia](../materias/programacion-web/)
-- Comunicaciones de Datos — [materia](../materias/comunicaciones-de-datos/)
-- Ingeniería de Software I — [materia](../materias/ingenieria-de-software-i/)
-- Probabilidad y Estadística — [materia](../materias/probabilidad-y-estadistica/)
-- Programación Avanzada — [materia](../materias/programacion-avanzada/)
-- Ingeniería de Software II — [materia](../materias/ingenieria-de-software-ii/)
+- Programación Web — no la curse tdv
+- Comunicaciones de Datos — [materia](../Materias/Comunicacion%20de%20datos%201/)
+- Ingeniería de Software I — [materia](../Materias/Ingenieria%20de%20Software%201/)
+- Probabilidad y Estadística — no la curse tdv
+- Programación Avanzada — no la curse tdv
+- Ingeniería de Software II — no la curse tdv
 
 > Al aprobar 3° año y la suficiencia de Inglés se obtiene el título de **Analista Programador Universitario**.
 
 ## 4° año
-- Inteligencia Artificial — [materia](../materias/inteligencia-artificial/)
-- Teoría de la Computación — [materia](../materias/teoria-de-la-computacion/)
-- Redes de Datos — [materia](../materias/redes-de-datos/)
-- Ingeniería de Software III — [materia](../materias/ingenieria-de-software-iii/)
-- Bases de Datos II — [materia](../materias/bases-de-datos-ii/)
-- Métodos Computacionales — [materia](../materias/metodos-computacionales/)
-- Análisis de Organizaciones y Procesos — [materia](../materias/analisis-de-organizaciones-y-procesos/)
+- Inteligencia Artificial — no la curse tdv
+- Teoría de la Computación — no la curse tdv
+- Redes de Datos — no la curse tdv
+- Ingeniería de Software III — no la curse tdv
+- Bases de Datos II — no la curse tdv
+- Métodos Computacionales — no la curse tdv
+- Análisis de Organizaciones y Procesos — no la curse tdv
 
 ## 5° año
-- Auditoría y Seguridad Informática — [materia](../materias/auditoria-y-seguridad-informatica/)
-- Emprendedorismo y Modelos de Negocios — [materia](../materias/emprendedorismo-y-modelos-de-negocios/)
-- Optativa I — [materia](../materias/optativa-i/)
-- Introducción a la Ciencia de Datos — [materia](../materias/introduccion-a-la-ciencia-de-datos/)
-- Aspectos Profesionales y Sociales de la Informática — [materia](../materias/aspectos-profesionales-y-sociales/)
-- Optativa II — [materia](../materias/optativa-ii/)
-- Proyecto Integrador de Carrera — [materia](../materias/proyecto-integrador-de-carrera/)
+- Auditoría y Seguridad Informática — no la curse tdv
+- Emprendedorismo y Modelos de Negocios — no la curse tdv
+- Optativa I — no la curse tdv
+- Introducción a la Ciencia de Datos — no la curse tdv
+- Aspectos Profesionales y Sociales de la Informática — no la curse tdv
+- Optativa II — no la curse tdv
+- Proyecto Integrador de Carrera — no la curse tdv


### PR DESCRIPTION
## Summary
- arregla links a carpetas existentes en planes 2009 y 2023
- marca materias sin carpeta como `no la curse tdv`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a658aa75c8832ea75e6f7869008b8a