### PR TITLE
docs: estandariza README por materia

### DIFF
--- a/Materias/Administracion y Gestion de Organizaciones/README.md
+++ b/Materias/Administracion y Gestion de Organizaciones/README.md
@@ -1,0 +1,60 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Excel-217346?style=for-the-badge&logo=microsoft-excel&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Administraci%C3%B3n-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 📈 Administración y Gestión de Organizaciones - UNNE 2024
+
+Esta carpeta reúne apuntes, prácticas y material del curso **Administración y Gestión de Organizaciones** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📎 material | Documentación de apoyo y lecturas complementarias |
+| 📝 practica | Actividades prácticas y ejercicios |
+| 📚 teoria | Apuntes teóricos de la materia |
+| 🏁 FINAL ADMIN | Material para el examen final |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Fundamentos de administración y gestión.
+- Estructura y diseño organizacional.
+- Estrategias y toma de decisiones.
+- Gestión de recursos humanos y liderazgo.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Excel-217346?style=for-the-badge&logo=microsoft-excel&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Material orientado a la comprensión de procesos administrativos y de gestión.
+- Contiene guías y prácticas utilizadas durante la cursada 2024.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Algoritmo y Estructura de datos 1/README.md
+++ b/Materias/Algoritmo y Estructura de datos 1/README.md
@@ -1,0 +1,60 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Informática-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🎓 Algoritmo y Estructura de Datos I - UNNE 2024
+
+Material de estudio, ejercicios y guías de la materia **Algoritmo y Estructura de Datos I** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📓 Clases de Algoritmo | Apuntes y diapositivas de las clases |
+| 💻 Dev C++ | Entorno y ejemplos en Dev-C++ |
+| 📍 Estrategias de Resolucion TP1-2 | Guía para los primeros trabajos prácticos |
+| 🗃️ Partes de un programa TP3 | Material del trabajo práctico 3 |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Fundamentos de programación imperativa.
+- Estructuras de datos lineales.
+- Modularización y funciones.
+- Algoritmos básicos de ordenamiento y búsqueda.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye ejercicios y material de apoyo para la cursada.
+- Ideal para repasar conceptos básicos de algoritmos.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Algoritmo y Estructura de datos 2/README.md
+++ b/Materias/Algoritmo y Estructura de datos 2/README.md
@@ -1,0 +1,61 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Informática-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🎓 Algoritmo y Estructura de Datos II - UNNE 2024
+
+Recursos y prácticos de la materia **Algoritmo y Estructura de Datos II** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 🔬 teoria | Apuntes teóricos y presentaciones |
+| 📝 Trabajos | Trabajos prácticos de la materia |
+| 🖊️ borradores | Bosquejos y notas previas |
+| 🎖️ 2do parcial | Material del segundo parcial |
+| 🛠️ trabajo integrador | Proyecto final integrador |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Estructuras dinámicas: listas, pilas y colas.
+- Recursividad y algoritmos divididos y vencerás.
+- Árboles y grafos.
+- Complejidad algorítmica y optimización.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye materiales de estudio y proyectos desarrollados en 2024.
+- Recomendado para consolidar estructuras de datos avanzadas.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Arquitectura de computadoras/README.md
+++ b/Materias/Arquitectura de computadoras/README.md
@@ -1,0 +1,60 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Logisim-000000?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/UNNE-Informática-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 💻 Arquitectura de Computadoras - UNNE 2024
+
+Apuntes, prácticos y herramientas de la materia **Arquitectura de Computadoras** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📚 teoria | Material teórico y presentaciones |
+| 🗒 Actividades practicas | Ejercicios y laboratorios |
+| 💾 Material pasado | Recursos de cursadas anteriores |
+| 🎖️ 2do parcial | Material de evaluación |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Representación de datos y sistemas de numeración.
+- Arquitectura de CPU y conjunto de instrucciones.
+- Memoria, buses y periferéricos.
+- Simulación de circuitos con Logisim.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Logisim-000000?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye simuladores y apuntes para preparar parciales.
+- Ideal para comprender la base del funcionamiento de las computadoras.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Calculo/README.md
+++ b/Materias/Calculo/README.md
@@ -1,0 +1,61 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/LaTeX-008080?style=for-the-badge&logo=latex&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-C%C3%A1lculo-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🎓 Cálculo - UNNE 2024
+
+Recopilación de apuntes, prácticas y exámenes de la materia **Cálculo** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 🎖️ 2do parcial | Material del segundo parcial |
+| 📋 años anteriores | Recursos de cursadas pasadas |
+| 📍 info importante | Información y comunicados |
+| 🗂️ modelos parciales | Modelos de exámenes |
+| 📗 teoria 2024 | Apuntes teóricos del año |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Límites y continuidad.
+- Derivadas y aplicaciones.
+- Integrales indefinidas y definidas.
+- Series y sucesiones.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/LaTeX-008080?style=for-the-badge&logo=latex&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye modelos de parciales y apuntes para estudiar.
+- Enfocado en la cursada 2024.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Comunicacion de datos 1/README.md
+++ b/Materias/Comunicacion de datos 1/README.md
@@ -1,0 +1,60 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Cisco-1BA0D7?style=for-the-badge&logo=cisco&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Redes-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 📶 Comunicación de Datos I - UNNE 2024
+
+Recursos, prácticos y evaluaciones de la materia **Comunicación de Datos I** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📝 practicos | Laboratorios y ejercicios de redes |
+| 📄 parciales | Exámenes y resoluciones |
+| 📎 archivos varios | Informes y TPs en formato PDF/DOC |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Modelo OSI y arquitectura de redes.
+- Protocolos TCP/IP y direccionamiento.
+- Topologías y dispositivos de red.
+- Herramientas de monitoreo y simulación.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Cisco-1BA0D7?style=for-the-badge&logo=cisco&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Wireshark-1679A7?style=for-the-badge&logo=wireshark&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Contiene reportes y prácticas de laboratorio realizadas en 2024.
+- Incluye guías de estudio para parciales.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Ingenieria de Software 1/README.md
+++ b/Materias/Ingenieria de Software 1/README.md
@@ -1,0 +1,61 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/UML-02569B?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/UNNE-Ingeniería-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🎓 Ingeniería de Software I - UNNE 2024
+
+Material, prácticos y proyectos de la materia **Ingeniería de Software I** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📚 Teoria | Apuntes y presentaciones teóricas |
+| 📝 Practica | Ejercicios y guías prácticas |
+| 👤 Materiales | Recursos adicionales |
+| 💪 Sistema Hospitalario | Proyecto aplicado a gestión hospitalaria |
+| 📄 Parciales Viejos | Exámenes de años anteriores |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Ciclo de vida del software y procesos de desarrollo.
+- Relevamiento y especificación de requisitos.
+- Modelado y diagramas UML.
+- Introducción a metodologías ágiles.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/UML-02569B?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye material para proyectos de análisis y diseño.
+- Enfocado en buenas prácticas de desarrollo.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Logica y Matematica Computacional/README.md
+++ b/Materias/Logica y Matematica Computacional/README.md
@@ -1,0 +1,60 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/LaTeX-008080?style=for-the-badge&logo=latex&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Lógica-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🤖 Lógica y Matemática Computacional - UNNE 2024
+
+Documentos y apuntes de la materia **Lógica y Matemática Computacional** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Archivo/Carpeta | Contenido |
+| --------------- | --------- |
+| 📝 Apuntes PDF | Desarrollo teórico de las unidades |
+| 📅 Presentaciones PPT | Material de clases y ejemplos |
+| 👍 Resúmenes | Síntesis para parciales y finales |
+| 📋 Otros | Programa de la materia e imágenes de apoyo |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Lógica proposicional y de predicados.
+- Relaciones de recurrencia.
+- Álgebra de Boole.
+- Grafos y lenguajes formales.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/LaTeX-008080?style=for-the-badge&logo=latex&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Contiene material variado utilizado durante la cursada 2024.
+- Incluye resúmenes y cuestionarios para repaso.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Paradigmas y Lenguajes/README.md
+++ b/Materias/Paradigmas y Lenguajes/README.md
@@ -1,0 +1,61 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Prolog-E61B23?style=for-the-badge&logo=prolog&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Paradigmas-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 📚 Paradigmas y Lenguajes - UNNE 2024
+
+Ejercicios y material de la materia **Paradigmas y Lenguajes** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📚 Teoria | Apuntes teóricos |
+| 📝 practica | Ejercicios guiados |
+| 👤 Material 2023 | Recursos de la cursada anterior |
+| 📁 data | Archivos de apoyo |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Paradigma imperativo y estructurado.
+- Programación funcional y recursiva.
+- Paradigma lógico con Prolog.
+- Comparativa entre distintos lenguajes.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Prolog-E61B23?style=for-the-badge&logo=prolog&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye ejercicios en distintos lenguajes.
+- Contiene material histórico y actual de la materia.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Sistemas Operativos/README.md
+++ b/Materias/Sistemas Operativos/README.md
@@ -1,0 +1,61 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black"/>
+  <img src="https://img.shields.io/badge/UNNE-Sistemas%20Operativos-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🖥️ Sistemas Operativos - UNNE 2024
+
+Material teórico, prácticos y evaluaciones de **Sistemas Operativos** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 📗 Teoria | Apuntes y libro de la materia |
+| 📝 Practicos | Ejercicios y guías de laboratorio |
+| 🎖️ Parciales 2024 | Evaluaciones del año |
+| 🗂️ modelo parciales anteriores | Modelos de exámenes |
+| 📋 resumenes | Resúmenes y cuestionarios |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Procesos, hilos y planificación.
+- Gestión de memoria y paginación.
+- Sistemas de archivos y dispositivos de E/S.
+- Sincronización y comunicación entre procesos.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Incluye guías y resúmenes para preparar el final.
+- Recopila material de la cursada 2024.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Sistemas y Organizaciones/README.md
+++ b/Materias/Sistemas y Organizaciones/README.md
@@ -1,0 +1,54 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/UNNE-Sistemas%20y%20Organizaciones-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 📄 Sistemas y Organizaciones - UNNE 2024
+
+Material de la materia **Sistemas y Organizaciones** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Archivo | Contenido |
+| ------- | --------- |
+| `TP2-Grupo 10.docx` | Trabajo práctico n.º 2 |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Análisis de sistemas y procesos organizacionales.
+- Gestión de información y toma de decisiones.
+- Modelado de procesos y documentación.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Carpeta en desarrollo con material de prácticos y teoría.
+- Enfocada en la organización de la información dentro de las empresas.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+

--- a/Materias/Taller de Programacion 2/README.md
+++ b/Materias/Taller de Programacion 2/README.md
@@ -1,0 +1,58 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tobiager/UNNE-LSI/main/assets/facena.png" alt="Logo de FaCENA" width="100">
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobiager">
+    <img src="https://img.shields.io/github/followers/tobiager?label=Follow%20@tobiager&style=social" alt="Follow @tobiager" />
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=java&logoColor=white"/>
+  <img src="https://img.shields.io/badge/UNNE-Taller%20II-blue?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Estado-En%20progreso-orange?style=for-the-badge"/>
+  <img src="https://img.shields.io/badge/Cursada-2024-blue?style=for-the-badge"/>
+</p>
+
+# 🤖 Taller de Programación II - UNNE 2024
+
+Ejercicios y material de **Taller de Programación II** de la **UNNE - FaCENA**.
+
+---
+
+## 📦 Estructura del Repositorio
+
+| Carpeta | Contenido |
+| ------- | --------- |
+| 👤 Material | Apuntes y recursos de la cursada |
+| 📝 practicos | Trabajos prácticos |
+
+---
+
+## 🚀 Temas principales y conceptos aplicados
+
+- Programación orientada a objetos avanzada.
+- Patrones de diseño.
+- Desarrollo de aplicaciones en Java.
+- Buenas prácticas y testing.
+
+---
+
+## 🧠 Tecnologías utilizadas
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=java&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Git-181717?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Markdown-000000?style=for-the-badge&logo=markdown&logoColor=white"/>
+</p>
+
+---
+
+## 📌 Notas
+
+- Contiene material utilizado en la cursada 2024.
+- Enfoque en el desarrollo de proyectos completos.
+
+<p align="center"><b>❤️ Hecho con dedicación por Tobias</b></p>
+


### PR DESCRIPTION
## Summary
- reformat subject READMEs using detailed template
- restore full versions of POO and Taller I guides

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6623a11f4832ea48066d45dbaa08a