### PR TITLE
docs: link to roadmap from status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ La carrera se dicta bajo dos planes vigentes:
 <p align="left">
   <img src="https://img.shields.io/badge/Avance-60%25-brightgreen?style=for-the-badge"/>
 </p>
+Ver progreso completo en [Roadmap](Roadmap.md).
 
 ### Materias en curso
 - ⏳ Taller de Programación II  


### PR DESCRIPTION
## Summary
- add prominent link to Roadmap in repo status section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6a0d10724832e81374c4b37ddedf2