### PR TITLE
Add correlatives to study plan JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Decidí armar este repositorio para dejar un registro de mi recorrido y que tamb
 
 Este espacio **NO es oficial**, pero vas a encontrar **apuntes, prácticos, guías, parciales resueltos y tips de cursada** de la **Licenciatura en Sistemas de Información (FaCENA – UNNE)**.
 
+👉 [Simulador de avance](./docs/simulador.html)
+
 > [!NOTE]
 > “El que estudia con parciales viejos, aprueba dos veces” — proverbio LSI
 

--- a/docs/plans.json
+++ b/docs/plans.json
@@ -1,0 +1,747 @@
+{
+  "2023": {
+    "nombre": "Plan 2023",
+    "materias": [
+      {
+        "codigo": "algoritmos-estructuras-i",
+        "nombre": "Algoritmos y Estructuras de Datos I",
+        "anio": 1,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": []
+      },
+      {
+        "codigo": "algebra",
+        "nombre": "Álgebra",
+        "anio": 1,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": []
+      },
+      {
+        "codigo": "algoritmos-estructuras-ii",
+        "nombre": "Algoritmos y Estructuras de Datos II",
+        "anio": 1,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-i"
+        ]
+      },
+      {
+        "codigo": "logica-matematica-computacional",
+        "nombre": "Lógica y Matemática Computacional",
+        "anio": 1,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algebra"
+        ]
+      },
+      {
+        "codigo": "sistemas-y-organizaciones",
+        "nombre": "Sistemas y Organizaciones",
+        "anio": 1,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": []
+      },
+      {
+        "codigo": "paradigmas-y-lenguajes",
+        "nombre": "Paradigmas y Lenguajes",
+        "anio": 2,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-i",
+          "algoritmos-estructuras-ii"
+        ]
+      },
+      {
+        "codigo": "arquitectura-y-organizacion-de-computadoras",
+        "nombre": "Arquitectura y Organización de Computadoras",
+        "anio": 2,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-i",
+          "logica-matematica-computacional"
+        ]
+      },
+      {
+        "codigo": "calculo-diferencial-e-integral",
+        "nombre": "Cálculo Diferencial e Integral",
+        "anio": 2,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algebra",
+          "logica-matematica-computacional"
+        ]
+      },
+      {
+        "codigo": "poo",
+        "nombre": "Programación Orientada a Objetos",
+        "anio": 2,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-ii",
+          "paradigmas-y-lenguajes"
+        ]
+      },
+      {
+        "codigo": "sistemas-operativos",
+        "nombre": "Sistemas Operativos",
+        "anio": 2,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "arquitectura-y-organizacion-de-computadoras"
+        ]
+      },
+      {
+        "codigo": "base-de-datos-i",
+        "nombre": "Bases de Datos I",
+        "anio": 2,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "arquitectura-y-organizacion-de-computadoras"
+        ]
+      },
+      {
+        "codigo": "programacion-web",
+        "nombre": "Programación Web",
+        "anio": 3,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "base-de-datos-i",
+          "paradigmas-y-lenguajes",
+          "poo"
+        ]
+      },
+      {
+        "codigo": "comunicaciones-de-datos",
+        "nombre": "Comunicaciones de Datos",
+        "anio": 3,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "arquitectura-y-organizacion-de-computadoras",
+          "sistemas-operativos"
+        ]
+      },
+      {
+        "codigo": "ingenieria-de-software-i",
+        "nombre": "Ingeniería de Software I",
+        "anio": 3,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "base-de-datos-i",
+          "paradigmas-y-lenguajes",
+          "poo"
+        ]
+      },
+      {
+        "codigo": "probabilidad-y-estadistica",
+        "nombre": "Probabilidad y Estadística",
+        "anio": 3,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "calculo-diferencial-e-integral",
+          "logica-matematica-computacional"
+        ]
+      },
+      {
+        "codigo": "programacion-avanzada",
+        "nombre": "Programación Avanzada",
+        "anio": 3,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "programacion-web"
+        ]
+      },
+      {
+        "codigo": "ingenieria-de-software-ii",
+        "nombre": "Ingeniería de Software II",
+        "anio": 3,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "base-de-datos-i",
+          "ingenieria-de-software-i"
+        ]
+      },
+      {
+        "codigo": "inteligencia-artificial",
+        "nombre": "Inteligencia Artificial",
+        "anio": 4,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "calculo-diferencial-e-integral",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "teoria-de-la-computacion",
+        "nombre": "Teoría de la Computación",
+        "anio": 4,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "calculo-diferencial-e-integral",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "redes-de-datos",
+        "nombre": "Redes de Datos",
+        "anio": 4,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "comunicaciones-de-datos",
+          "sistemas-operativos"
+        ]
+      },
+      {
+        "codigo": "ingenieria-de-software-iii",
+        "nombre": "Ingeniería de Software III",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "ingenieria-de-software-i",
+          "ingenieria-de-software-ii"
+        ]
+      },
+      {
+        "codigo": "bases-de-datos-ii",
+        "nombre": "Bases de Datos II",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "base-de-datos-i",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "metodos-computacionales",
+        "nombre": "Métodos Computacionales",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "calculo-diferencial-e-integral",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "analisis-de-organizaciones-y-procesos",
+        "nombre": "Análisis de Organizaciones y Procesos",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "ingenieria-de-software-ii",
+          "sistemas-y-organizaciones"
+        ]
+      },
+      {
+        "codigo": "auditoria-y-seguridad-informatica",
+        "nombre": "Auditoría y Seguridad Informática",
+        "anio": 5,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "inteligencia-artificial",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "emprendedorismo-y-modelos-de-negocios",
+        "nombre": "Emprendedorismo y Modelos de Negocios",
+        "anio": 5,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "ingenieria-de-software-i",
+          "ingenieria-de-software-ii"
+        ]
+      },
+      {
+        "codigo": "optativa-i",
+        "nombre": "Optativa I",
+        "anio": 5,
+        "cuatrimestre": 1,
+        "regimen": "Bimestral",
+        "carga_horaria": 48,
+        "correlativas": [
+          "comunicaciones-de-datos",
+          "ingenieria-de-software-i",
+          "ingenieria-de-software-ii",
+          "probabilidad-y-estadistica",
+          "programacion-avanzada",
+          "programacion-web"
+        ]
+      },
+      {
+        "codigo": "introduccion-a-la-ciencia-de-datos",
+        "nombre": "Introducción a la Ciencia de Datos",
+        "anio": 5,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "ingenieria-de-software-iii",
+          "redes-de-datos"
+        ]
+      },
+      {
+        "codigo": "aspectos-profesionales-y-sociales",
+        "nombre": "Aspectos Profesionales y Sociales de la Informática",
+        "anio": 5,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "emprendedorismo-y-modelos-de-negocios",
+          "ingenieria-de-software-ii"
+        ]
+      },
+      {
+        "codigo": "optativa-ii",
+        "nombre": "Optativa II",
+        "anio": 5,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 48,
+        "correlativas": [
+          "comunicaciones-de-datos",
+          "ingenieria-de-software-i",
+          "ingenieria-de-software-ii",
+          "probabilidad-y-estadistica",
+          "programacion-avanzada",
+          "programacion-web"
+        ]
+      },
+      {
+        "codigo": "proyecto-integrador-de-carrera",
+        "nombre": "Proyecto Integrador de Carrera",
+        "anio": 5,
+        "cuatrimestre": "anual",
+        "regimen": "Anual",
+        "carga_horaria": 128,
+        "correlativas": [
+          "analisis-de-organizaciones-y-procesos",
+          "bases-de-datos-ii",
+          "ingenieria-de-software-ii",
+          "ingenieria-de-software-iii",
+          "inteligencia-artificial",
+          "metodos-computacionales",
+          "programacion-avanzada",
+          "redes-de-datos",
+          "teoria-de-la-computacion"
+        ]
+      }
+    ]
+  },
+  "2009": {
+    "nombre": "Plan 2009",
+    "materias": [
+      {
+        "codigo": "algoritmos-estructuras-i",
+        "nombre": "Algoritmos y Estructuras de Datos I",
+        "anio": 1,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": []
+      },
+      {
+        "codigo": "algebra",
+        "nombre": "Álgebra",
+        "anio": 1,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": []
+      },
+      {
+        "codigo": "algoritmos-estructuras-ii",
+        "nombre": "Algoritmos y Estructuras de Datos II",
+        "anio": 1,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-i"
+        ]
+      },
+      {
+        "codigo": "logica-matematica-computacional",
+        "nombre": "Lógica y Matemática Computacional",
+        "anio": 1,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algebra"
+        ]
+      },
+      {
+        "codigo": "sistemas-y-organizaciones",
+        "nombre": "Sistemas y Organizaciones",
+        "anio": 1,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": []
+      },
+      {
+        "codigo": "paradigmas-y-lenguajes",
+        "nombre": "Paradigmas y Lenguajes",
+        "anio": 2,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-i",
+          "algoritmos-estructuras-ii"
+        ]
+      },
+      {
+        "codigo": "arquitectura-y-organizacion-de-computadoras",
+        "nombre": "Arquitectura y Organización de Computadoras",
+        "anio": 2,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-i",
+          "logica-matematica-computacional"
+        ]
+      },
+      {
+        "codigo": "calculo-diferencial-e-integral",
+        "nombre": "Cálculo Diferencial e Integral",
+        "anio": 2,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algebra",
+          "logica-matematica-computacional"
+        ]
+      },
+      {
+        "codigo": "poo",
+        "nombre": "Programación Orientada a Objetos",
+        "anio": 2,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-ii",
+          "paradigmas-y-lenguajes"
+        ]
+      },
+      {
+        "codigo": "sistemas-operativos",
+        "nombre": "Sistemas Operativos",
+        "anio": 2,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "algoritmos-estructuras-ii",
+          "arquitectura-y-organizacion-de-computadoras"
+        ]
+      },
+      {
+        "codigo": "administracion-y-gestion-de-organizaciones",
+        "nombre": "Administración y Gestión de Organizaciones",
+        "anio": 2,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "sistemas-y-organizaciones"
+        ]
+      },
+      {
+        "codigo": "comunicaciones-de-datos",
+        "nombre": "Comunicaciones de Datos",
+        "anio": 3,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "arquitectura-y-organizacion-de-computadoras",
+          "sistemas-operativos"
+        ]
+      },
+      {
+        "codigo": "ingenieria-de-software-i",
+        "nombre": "Ingeniería de Software I",
+        "anio": 3,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "administracion-y-gestion-de-organizaciones",
+          "poo",
+          "sistemas-y-organizaciones"
+        ]
+      },
+      {
+        "codigo": "taller-de-programacion-i",
+        "nombre": "Taller de Programación I",
+        "anio": 3,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "paradigmas-y-lenguajes",
+          "poo"
+        ]
+      },
+      {
+        "codigo": "base-de-datos-i",
+        "nombre": "Bases de Datos I",
+        "anio": 3,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "arquitectura-y-organizacion-de-computadoras",
+          "ingenieria-de-software-i"
+        ]
+      },
+      {
+        "codigo": "probabilidad-y-estadistica",
+        "nombre": "Probabilidad y Estadística",
+        "anio": 3,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "calculo-diferencial-e-integral"
+        ]
+      },
+      {
+        "codigo": "taller-de-programacion-ii",
+        "nombre": "Taller de Programación II",
+        "anio": 3,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "ingenieria-de-software-i",
+          "poo",
+          "sistemas-operativos",
+          "taller-de-programacion-i"
+        ]
+      },
+      {
+        "codigo": "ingles-tecnico-informatico",
+        "nombre": "Inglés Técnico Informático (exigencia extracurricular para APU)",
+        "anio": 3,
+        "cuatrimestre": "extracurricular",
+        "regimen": "Extracurricular",
+        "carga_horaria": 0,
+        "correlativas": []
+      },
+      {
+        "codigo": "ingenieria-de-software-ii",
+        "nombre": "Ingeniería de Software II",
+        "anio": 4,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "administracion-y-gestion-de-organizaciones",
+          "ingenieria-de-software-i"
+        ]
+      },
+      {
+        "codigo": "teoria-de-la-computacion",
+        "nombre": "Teoría de la Computación",
+        "anio": 4,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "arquitectura-y-organizacion-de-computadoras",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "economia-aplicada",
+        "nombre": "Economía Aplicada",
+        "anio": 4,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "administracion-y-gestion-de-organizaciones",
+          "ingenieria-de-software-i"
+        ]
+      },
+      {
+        "codigo": "redes-de-datos",
+        "nombre": "Redes de Datos",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "comunicaciones-de-datos"
+        ]
+      },
+      {
+        "codigo": "bases-de-datos-ii",
+        "nombre": "Bases de Datos II",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "base-de-datos-i",
+          "ingenieria-de-software-i"
+        ]
+      },
+      {
+        "codigo": "metodos-computacionales",
+        "nombre": "Métodos Computacionales",
+        "anio": 4,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 128,
+        "correlativas": [
+          "calculo-diferencial-e-integral",
+          "probabilidad-y-estadistica"
+        ]
+      },
+      {
+        "codigo": "auditoria-y-seguridad-informatica",
+        "nombre": "Auditoría y Seguridad Informática",
+        "anio": 5,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "bases-de-datos-ii",
+          "ingenieria-de-software-ii",
+          "redes-de-datos"
+        ]
+      },
+      {
+        "codigo": "optativa-i",
+        "nombre": "Optativa I",
+        "anio": 5,
+        "cuatrimestre": 1,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "probabilidad-y-estadistica",
+          "teoria-de-la-computacion"
+        ]
+      },
+      {
+        "codigo": "optativa-ii",
+        "nombre": "Optativa II",
+        "anio": 5,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "comunicaciones-de-datos",
+          "redes-de-datos"
+        ]
+      },
+      {
+        "codigo": "optativa-iii",
+        "nombre": "Optativa III",
+        "anio": 5,
+        "cuatrimestre": 2,
+        "regimen": "Cuatrimestral",
+        "carga_horaria": 96,
+        "correlativas": [
+          "bases-de-datos-ii",
+          "ingenieria-de-software-ii"
+        ]
+      },
+      {
+        "codigo": "proyecto-integrador-de-carrera",
+        "nombre": "Proyecto Integrador de Carrera",
+        "anio": 5,
+        "cuatrimestre": "anual",
+        "regimen": "Anual",
+        "carga_horaria": 192,
+        "correlativas": [
+          "administracion-y-gestion-de-organizaciones",
+          "algebra",
+          "algoritmos-estructuras-i",
+          "algoritmos-estructuras-ii",
+          "arquitectura-y-organizacion-de-computadoras",
+          "auditoria-y-seguridad-informatica",
+          "base-de-datos-i",
+          "bases-de-datos-ii",
+          "calculo-diferencial-e-integral",
+          "comunicaciones-de-datos",
+          "economia-aplicada",
+          "ingenieria-de-software-i",
+          "ingenieria-de-software-ii",
+          "logica-matematica-computacional",
+          "metodos-computacionales",
+          "optativa-i",
+          "optativa-ii",
+          "optativa-iii",
+          "paradigmas-y-lenguajes",
+          "poo",
+          "probabilidad-y-estadistica",
+          "redes-de-datos",
+          "sistemas-operativos",
+          "sistemas-y-organizaciones",
+          "taller-de-programacion-i",
+          "taller-de-programacion-ii",
+          "teoria-de-la-computacion"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Simulador de Avance</title>
+<style>
+body{font-family:Arial,Helvetica,sans-serif;background:#121212;color:#eee;margin:0;padding:1rem;}
+#controls{margin-bottom:1rem;}
+#materias{display:flex;flex-wrap:wrap;gap:0.5rem;}
+.card{border:1px solid #444;border-radius:8px;padding:0.5rem;background:#333;flex:1 1 300px;cursor:pointer;}
+.card.no{background:#444;}
+.card.regular{background:#b59f3b;}
+.card.aprobada{background:#2e7d32;}
+.card.disabled{opacity:0.4;cursor:not-allowed;}
+.badges span{margin-right:0.3rem;background:#555;padding:0.1rem 0.3rem;border-radius:4px;font-size:0.8rem;}
+@media(max-width:600px){.card{flex:1 1 100%;}}
+</style>
+</head>
+<body>
+<h1>Simulador de Avance</h1>
+<div id="controls">
+  <select id="plan"></select>
+  <button id="save">Guardar</button>
+  <button id="reset">Reiniciar</button>
+  <button id="export">Exportar JSON</button>
+  <button id="import">Importar JSON</button>
+  <input type="file" id="fileInput" style="display:none" />
+</div>
+<div id="stats"></div>
+<div id="materias"></div>
+<script>
+const STORAGE_KEY='simulador-avance';
+let plans={},currentPlan='2023',states={};
+fetch('plans.json').then(r=>r.json()).then(data=>{
+  plans=data;
+  const sel=document.getElementById('plan');
+  Object.entries(plans).forEach(([key,plan])=>{
+    const opt=document.createElement('option');
+    opt.value=key;opt.textContent=plan.nombre;sel.appendChild(opt);
+  });
+  sel.addEventListener('change',()=>{currentPlan=sel.value;loadStates();render();});
+  loadStates();render();
+});
+function loadStates(){
+  const all=JSON.parse(localStorage.getItem(STORAGE_KEY)||'{}');
+  states=all[currentPlan]||{};
+}
+function saveStates(){
+  const all=JSON.parse(localStorage.getItem(STORAGE_KEY)||'{}');
+  all[currentPlan]=states;
+  localStorage.setItem(STORAGE_KEY,JSON.stringify(all));
+}
+function resetStates(){
+  states={};
+  saveStates();
+  render();
+}
+function toggleState(code){
+  const s=states[code]||0;
+  states[code]=(s+1)%3;
+  saveStates();
+  render();
+}
+function allowed(code){
+  const mat=plans[currentPlan].materias.find(m=>m.codigo===code);
+  return mat.correlativas.every(c=>(states[c]||0)==2);
+}
+function render(){
+  const container=document.getElementById('materias');
+  container.innerHTML='';
+  plans[currentPlan].materias.forEach(m=>{
+    const card=document.createElement('div');
+    card.className='card';
+    const state=states[m.codigo]||0;
+    card.classList.add(['no','regular','aprobada'][state]);
+    if(!allowed(m.codigo))card.classList.add('disabled');
+    card.innerHTML=`<strong>${m.codigo} — ${m.nombre}</strong><div class="badges"><span>Año: ${m.anio}</span><span>Cuatr: ${m.cuatrimestre}</span><span>${m.regimen}</span><span>${m.carga_horaria}h</span></div>`+(m.correlativas.length?`<div>Correlativas: ${m.correlativas.join(', ')}</div>`:'');
+    if(allowed(m.codigo))card.addEventListener('click',()=>toggleState(m.codigo));
+    container.appendChild(card);
+  });
+  updateStats();
+}
+function updateStats(){
+  const counts={0:0,1:0,2:0};
+  plans[currentPlan].materias.forEach(m=>{counts[states[m.codigo]||0]++;});
+  document.getElementById('stats').textContent=`Aprobadas: ${counts[2]} | Regulares: ${counts[1]} | No cursadas: ${counts[0]} | Total: ${plans[currentPlan].materias.length}`;
+}
+document.getElementById('save').addEventListener('click',saveStates);
+document.getElementById('reset').addEventListener('click',resetStates);
+document.getElementById('export').addEventListener('click',()=>{
+  const data=localStorage.getItem(STORAGE_KEY)||'{}';
+  const blob=new Blob([data],{type:'application/json'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download='simulador.json';
+  a.click();
+});
+document.getElementById('import').addEventListener('click',()=>document.getElementById('fileInput').click());
+document.getElementById('fileInput').addEventListener('change',e=>{
+  const file=e.target.files[0];
+  if(!file)return;
+  const reader=new FileReader();
+  reader.onload=ev=>{
+    try{
+      localStorage.setItem(STORAGE_KEY,ev.target.result);
+      loadStates();
+      render();
+    }catch(err){alert('JSON inválido');}
+  };
+  reader.readAsText(file);
+});
+</script>
+</body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,3 +23,4 @@ nav:
   - Planes:
       - "2009": "planes/2009.md"
       - "2023": "planes/2023.md"
+  - Simulador: docs/simulador.html


### PR DESCRIPTION
## Summary
- populate correlatives for all subjects in plans.json for 2023 and 2009 plans

## Testing
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb7d67c00832eb1606590359c569f