### PR TITLE
Centrar footer y enlazar GitHub

### DIFF
--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -102,20 +102,16 @@
   }
   .footer-inner{
     max-width:1180px;margin:0 auto;height:100%;
-    display:flex;align-items:center;justify-content:space-between;
-    padding:0 24px;font-size:.9rem;
+    display:flex;align-items:center;justify-content:center;
+    gap:8px;flex-wrap:wrap;
+    padding:0 24px;font-size:.9rem;text-align:center;
   }
-  .footer-inner .credits{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-  .footer-inner .links{display:flex;align-items:center;gap:16px}
-  .icon-link{
+  .gh-link{
     display:inline-flex;align-items:center;gap:6px;
-    padding:4px 8px;border-radius:8px;
-    background:#1e293b;color:#cfe1ff;text-decoration:none;
-    transition:background .2s,transform .2s;
+    color:#3b82f6;font-weight:600;text-decoration:none;
   }
-  .icon-link:hover{background:#27364a;transform:translateY(-2px)}
-  .icon-link svg{width:18px;height:18px;fill:currentColor}
-  .sep{opacity:.6;margin:0 .3rem}
+  .gh-link:hover{text-decoration:underline}
+  .gh-link svg{width:18px;height:18px;fill:currentColor}
   a{color:#9cc9ff;text-decoration:none}
   a:hover{text-decoration:underline}
 
@@ -179,21 +175,16 @@
 <!-- ===== Footer sticky ===== -->
 <footer>
   <div class="footer-inner">
-    <div class="credits">
-      <span>© 2025 Simulador de Avance</span>
-      <span class="sep">·</span>
-      <span>Todos los derechos reservados</span>
-    </div>
-    <div class="links">
-      <a class="icon-link" href="https://github.com/tobiager" target="_blank" rel="noopener">
-        <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        Tobías
-      </a>
-      <a class="icon-link" href="https://github.com/tobiager/UNNE-LSI" target="_blank" rel="noopener">
-        <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        Repo
-      </a>
-    </div>
+    <span>Hecho con pasión y dedicación por</span>
+    <a class="gh-link" href="https://github.com/tobiager" target="_blank" rel="noopener">
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      Tobías
+    </a>
+    <span>y</span>
+    <a class="gh-link" href="https://github.com/tobiager/UNNE-LSI" target="_blank" rel="noopener">
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      Repositorio de LSI
+    </a>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary
- Centrar y simplificar el footer del simulador
- Agregar mensaje con enlaces resaltados a GitHub para el autor y el repositorio

## Testing
- `npm test` *(falló: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abe32acbbc832eaed2a3781e0992a1