### PR TITLE
feat: add responsive breakpoints for simulador

### DIFF
--- a/docs/css/simulador.css
+++ b/docs/css/simulador.css
@@ -1,0 +1,34 @@
+/* Responsive layout for simulador */
+
+#materias {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(320px, 1fr));
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+/* Adjust layout for medium screens */
+@media (max-width: 1200px) {
+  #materias {
+    grid-template-columns: repeat(2, minmax(320px, 1fr));
+  }
+}
+
+/* Stack content on small screens */
+@media (max-width: 600px) {
+  #materias {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive CSS breakpoints at 1200px and 600px for `#materias`
- stack toolbar vertically on small screens to prevent overlap

## Testing
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs` *(fails: Could not find a version that satisfies the requirement mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_68abea5b8624832e9298d7362fe84830