### PR TITLE
feat: collapsible status bar and single-line footer

### DIFF
--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -104,7 +104,16 @@
     z-index:20; background:rgba(11,15,20,.75); backdrop-filter:saturate(130%) blur(8px);
     border-top:1px solid var(--border);
   }
+  .statusbar>summary{
+    list-style:none;cursor:pointer;
+    display:flex;align-items:center;justify-content:center;
+    color:var(--muted);padding:4px 0;
+  }
+  .statusbar>summary::-webkit-details-marker{display:none}
+  .statusbar[open]>summary::after{content:'\25BC'}
+  .statusbar:not([open])>summary::after{content:'\25B2'}
   .status-inner{max-width:1180px;margin:0 auto;padding:10px 16px;display:flex;gap:16px;align-items:center;flex-wrap:wrap}
+  .statusbar:not([open]) .status-inner{display:none}
   .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--panel);font-weight:700;font-size:.82rem}
   .pill.green{border-color:#1f6d3c;background:#0f2717;color:#9df2c9}
   .pill.yellow{border-color:#8b6a1b;background:#2a220d;color:#fde68a}
@@ -130,7 +139,7 @@
   .footer-inner{
     max-width:1180px;margin:0 auto;height:100%;
     display:flex;align-items:center;justify-content:center;
-    gap:8px;flex-wrap:wrap;
+    gap:8px;flex-wrap:nowrap;white-space:nowrap;overflow-x:auto;
     padding:0 24px;font-size:.9rem;text-align:center;
   }
   .gh-link{
@@ -207,7 +216,8 @@
   <div id="materias"></div>
 </main>
 
-<div class="statusbar">
+<details id="statusbar" class="statusbar" open>
+  <summary></summary>
   <div class="status-inner">
     <div class="pill green">Aprobadas: <span id="cAprob">0</span></div>
     <div class="pill yellow">Regulares: <span id="cReg">0</span></div>
@@ -226,7 +236,7 @@
       <span id="pLic" class="pct">0%</span>
     </div>
   </div>
-</div>
+</details>
 
 <footer>
   <div class="footer-inner">
@@ -550,6 +560,14 @@ themeBtn.addEventListener('click',()=>{
   localStorage.setItem('theme',next);
   themeBtn.textContent=isDark?'🌜':'🌞';
 });
+
+const statusBar=document.getElementById('statusbar');
+function updateStatusHeight(){
+  const h=statusBar.open?statusBar.offsetHeight:statusBar.querySelector('summary').offsetHeight;
+  document.body.style.setProperty('--status-h',h+'px');
+}
+statusBar.addEventListener('toggle',updateStatusHeight);
+updateStatusHeight();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Make status bar collapsible to free screen space
- Keep footer contents on a single line

## Testing
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs` *(fails: Could not find a version that satisfies the requirement mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_68abf16ef85c832ebb728fcbfdafb5e7