### PR TITLE
fix: restore desktop toolbar layout

### DIFF
--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -44,6 +44,28 @@
     padding:8px 12px;border-radius:12px;font-weight:600
   }
   .legend{display:flex;flex-wrap:wrap;gap:12px;margin-left:auto}
+  .toolbar details.menu>summary{
+    cursor:pointer;
+    background:var(--panel);border:1px solid var(--border);color:var(--text);
+    padding:8px 12px;border-radius:12px;font-weight:600
+  }
+  .toolbar details.menu>.menu-content{flex-wrap:wrap;gap:10px;margin-top:8px}
+  .toolbar details.menu .legend{margin-left:0}
+
+  /* Mobile: show arrow and keep menu cerrado por defecto */
+  @media (max-width:699px){
+    .toolbar details.menu>.menu-content{display:none}
+    .toolbar details.menu[open]>.menu-content{display:flex}
+    .toolbar select,.toolbar input[type="search"]{flex:1 1 100%}
+    .toolbar details.menu{width:100%}
+  }
+
+  /* Desktop: mostrar opciones siempre y ocultar el trigger */
+  @media (min-width:700px){
+    .toolbar details.menu>summary{display:none}
+    .toolbar details.menu{display:flex;flex-wrap:wrap;gap:10px}
+    .toolbar details.menu>.menu-content{display:flex !important;margin-top:0}
+  }
   .dot{width:12px;height:12px;border-radius:999px;display:inline-block;margin-right:6px}
 
   main{padding:10px 0 24px}
@@ -160,21 +182,26 @@
     <div class="toolbar">
       <select id="plan"></select>
       <input id="search" type="search" placeholder="Buscar materia..." />
-      <label><input type="checkbox" id="onlyEnabled"> Solo habilitadas</label>
-      <button id="save">Guardar</button>
-      <button id="reset">Reiniciar</button>
-      <button id="export">Exportar JSON</button>
-      <button id="import">Importar JSON</button>
-      <button id="share">Link de estado</button>
-      <button id="badgeYear">Copiar badge · Año</button>
-      <button id="badgePct">Copiar badge · %</button>
-      <button id="themeToggle">Tema</button>
-      <input type="file" id="fileInput" accept="application/json" style="display:none" />
-      <div class="legend">
-        <span><span class="dot" style="background:#3b414c"></span>No cursada</span>
-        <span><span class="dot" style="background:#b59f3b"></span>Regular</span>
-        <span><span class="dot" style="background:#16a34a"></span>Aprobada</span>
-      </div>
+      <details id="menu" class="menu">
+        <summary>Opciones</summary>
+        <div class="menu-content">
+          <label><input type="checkbox" id="onlyEnabled"> Solo habilitadas</label>
+          <button id="save">Guardar</button>
+          <button id="reset">Reiniciar</button>
+          <button id="export">Exportar JSON</button>
+          <button id="import">Importar JSON</button>
+          <button id="share">Link de estado</button>
+          <button id="badgeYear">Copiar badge · Año</button>
+          <button id="badgePct">Copiar badge · %</button>
+          <button id="themeToggle">Tema</button>
+          <input type="file" id="fileInput" accept="application/json" style="display:none" />
+          <div class="legend">
+            <span><span class="dot" style="background:#3b414c"></span>No cursada</span>
+            <span><span class="dot" style="background:#b59f3b"></span>Regular</span>
+            <span><span class="dot" style="background:#16a34a"></span>Aprobada</span>
+          </div>
+        </div>
+      </details>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- keep options menu collapsed only on small screens
- always show toolbar actions on desktop and hide toggle arrow

## Testing
- ⚠️ `mkdocs build` (mkdocs: command not found)
- ⚠️ `pip install mkdocs` (Cannot connect to proxy)


------
https://chatgpt.com/codex/tasks/task_e_68abef31ca14832ea5a57204d41b120b