### PR TITLE
Ajusta tamaño del texto del footer según pantalla

### DIFF
--- a/docs/estado.html
+++ b/docs/estado.html
@@ -60,7 +60,10 @@
     max-width:1180px;margin:0 auto;height:100%;
     display:flex;align-items:center;justify-content:center;
     gap:8px;flex-wrap:wrap;
-    padding:0 24px;font-size:.9rem;text-align:center;
+    padding:0 24px;text-align:center;
+  }
+  @media (max-width:600px){
+    .footer-inner{font-size:0.75rem;}
   }
   .gh-link{
     display:inline-flex;align-items:center;gap:6px;

--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -151,7 +151,10 @@ padding:8px 12px;border-radius:12px;font-weight:600
     max-width:1180px;margin:0 auto;height:100%;
     display:flex;align-items:center;justify-content:center;
     gap:8px;flex-wrap:nowrap;white-space:nowrap;overflow-x:auto;
-    padding:0 24px;font-size:.9rem;text-align:center;
+    padding:0 24px;text-align:center;
+  }
+  @media (max-width:600px){
+    .footer-inner{font-size:0.75rem;}
   }
   .gh-link{
     display:inline-flex;align-items:center;gap:6px;


### PR DESCRIPTION
## Summary
- Restaura el tamaño de fuente por defecto en los footers de estado y simulador
- Añade media query para reducir la fuente del footer a 0.75rem en pantallas pequeñas

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf91b8b38832ea3548495b0f2a363