### PR TITLE
Show analista and licenciado progress in estado view

### DIFF
--- a/docs/estado.html
+++ b/docs/estado.html
@@ -33,8 +33,12 @@
   .wrap{max-width:900px;margin:0 auto;padding:16px}
   h1{margin:0 0 16px;font-size:1.8rem}
   .panel{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:16px;margin-bottom:16px}
-  .meter{height:10px;border-radius:999px;background:var(--panel);border:1px solid var(--border);overflow:hidden}
-  .meter>span{display:block;height:100%;width:0;background:linear-gradient(90deg,#22c55e,#16a34a)}
+  .bar{display:flex;align-items:center;gap:10px;min-width:280px}
+  .meter{height:10px;border-radius:999px;background:var(--panel);border:1px solid var(--border);overflow:hidden;flex:1}
+  .meter>span{display:block;height:100%;width:0%}
+  .m-green{background:linear-gradient(90deg,#22c55e,#16a34a)}
+  .m-blue{background:linear-gradient(90deg,#60a5fa,#3b82f6)}
+  .pct{min-width:3.5ch;text-align:right;color:#a7f3d0;font-weight:800}
   .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:14px;margin-top:12px}
   .card{border:1px solid var(--border);border-radius:14px;padding:12px;background:linear-gradient(180deg,var(--card),var(--card2));position:relative}
   .ttl{font-weight:800;margin:0 0 6px}
@@ -116,12 +120,36 @@ document.body.classList.add(savedTheme);
   arr.forEach(m=>counts[share.states?.[m.codigo]||0]++);
   const total=arr.length, pct= total? Math.round(100*counts[2]/total):0;
 
+  const anaSet = new Set(arr.filter(m=>Number(m.anio)<=3).map(m=>m.codigo));
+  const anaTotal = anaSet.size;
+  const anaAprob = Array.from(anaSet).filter(c=> (share.states?.[c]||0)===2).length;
+  const anaPct = anaTotal ? Math.round(100*anaAprob/anaTotal) : 0;
+
+  const licTotal = arr.length;
+  const licAprob = counts[2];
+  const licPct   = licTotal ? Math.round(100*licAprob/licTotal) : 0;
+
   const head=document.getElementById('head');
   head.innerHTML = `
     <div><strong>Plan:</strong> ${plan.nombre}</div>
     <div style="margin:6px 0">Aprobadas: ${counts[2]} · Regulares: ${counts[1]} · No: ${counts[0]} · Total: ${total}</div>
-    <div class="meter"><span style="width:${pct}%"></span></div>
+    <div class="meter"><span class="m-green" style="width:${pct}%"></span></div>
+    <div class="bar" title="Avance Analista (años 1–3)">
+      <span style="white-space:nowrap;color:#9fb0c2">Analista</span>
+      <div class="meter"><span id="mAnalista" class="m-blue"></span></div>
+      <span id="pAna" class="pct">0%</span>
+    </div>
+    <div class="bar" title="Avance Licenciado/a (total)">
+      <span style="white-space:nowrap;color:#9fb0c2">Licenciado/a</span>
+      <div class="meter"><span id="mLic" class="m-green"></span></div>
+      <span id="pLic" class="pct">0%</span>
+    </div>
   `;
+
+  document.getElementById('mAnalista').style.width = anaPct + '%';
+  document.getElementById('pAna').textContent      = anaPct + '%';
+  document.getElementById('mLic').style.width = licPct + '%';
+  document.getElementById('pLic').textContent = licPct + '%';
 
   // listado compacto
   const byYear={};


### PR DESCRIPTION
## Summary
- add progress bars for Analista and Licenciado/a on estado view
- compute and display percentages for each certificate

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abfb3db5d4832e8dd955bca2a3e655