### PR TITLE
Fix licenciado progress calculation in simulator

### DIFF
--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -505,7 +505,7 @@ function updateStats(){
   const arr=plans[currentPlan].materias||[];
 
   const counts={0:0,1:0,2:0,3:0};
-  arr.forEach(m=>{counts[states[m.codigo]||0]++;});
+  arr.forEach(m=>{counts[getStatus(m.codigo)]++;});
 
 
   document.getElementById('cAprob').textContent = counts[2];


### PR DESCRIPTION
## Summary
- fix subject state counting using `getStatus`
- ensure licenciado progress and totals display correctly

## Testing
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs` *(fails: cannot connect to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac00e2a414832eb0770bd08d792830