### PR TITLE
Use local badge images for year badge

### DIFF
--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -577,11 +577,18 @@ function colorByPct(p){
 }
 function makeYearBadgeMarkdown(){
   const year = highestFullYearApproved();
-  const label = encodeURIComponent('🎓 LSI');
-  const msg   = encodeURIComponent( year===0 ? 'Ingresante' : `${year}º año` );
-  const color = '16a34a';
-  const url = `https://img.shields.io/badge/${label}-${msg}-${color}?style=${BADGE_STYLE}`;
-  return `[![LSI · ${year===0?'Ingresante':year+'º año'}](${url})](${shareUrl()})`;
+  const files={
+    0:'1er-año.png',
+    1:'1er-año.png',
+    2:'2do-año.PNG',
+    3:'3er-año.PNG',
+    4:'4to-año.PNG',
+    5:'5to-año.PNG'
+  };
+  const file=files[year]||files[0];
+  const imgUrl=new URL('../assets/badges/'+file,location.href).href;
+  const alt=`LSI · ${year===0?'Ingresante':year+'º año'}`;
+  return `[![${alt}](${imgUrl})](${shareUrl()})`;
 }
 function makePctBadgeMarkdown(){
   const pct = computeLicPct();


### PR DESCRIPTION
## Summary
- Replace Shields.io badge for "Copiar badge · Año" with local images in `assets/badges`
- Map approved year to corresponding local badge image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0126056c832e8958525c50ccd6fb