### PR TITLE
Fix licenciado progress calculation in simulator

### DIFF
--- a/docs/estado.html
+++ b/docs/estado.html
@@ -112,7 +112,6 @@ document.body.classList.add(savedTheme);
     }catch{ return null; }
   }
   const share=decodeHash();
-  function getStatus(code){ return share?.states?.[code] ?? 0; }
   if(!share){ document.getElementById('head').textContent='Sin datos.'; return; }
   const plans = await (await fetch('plans.json')).json();
   const plan = plans[share.plan];

--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -505,7 +505,7 @@ function updateStats(){
   const arr=plans[currentPlan].materias||[];
 
   const counts={0:0,1:0,2:0,3:0};
-  arr.forEach(m=>{counts[states[m.codigo]||0]++;});
+  arr.forEach(m=>{counts[getStatus(m.codigo)]++;});
 
 
   document.getElementById('cAprob').textContent = counts[2];


### PR DESCRIPTION
## Summary
- fix subject state counting using `getStatus`
- ensure licenciado progress and totals display correctly
- remove duplicate status lookup for shared career states

## Testing
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ac00e2a414832eb0770bd08d792830