### PR TITLE
Use most advanced year for badge

### DIFF
--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -550,6 +550,15 @@ function highestFullYearApproved(){
   }
   return max;
 }
+function highestYearWithProgress(){
+  const arr=(plans[currentPlan].materias||[]);
+  let max=0;
+  arr.forEach(m=>{
+    const y=Number(m.anio);
+    if(getStatus(m.codigo)>0 && y>max) max=y;
+  });
+  return max;
+}
 function currentShareHash(){
   const payload={ plan: currentPlan, states };
   const json=JSON.stringify(payload);
@@ -576,12 +585,19 @@ function colorByPct(p){
   return '64748b';
 }
 function makeYearBadgeMarkdown(){
-  const year = highestFullYearApproved();
-  const label = encodeURIComponent('🎓 LSI');
-  const msg   = encodeURIComponent( year===0 ? 'Ingresante' : `${year}º año` );
-  const color = '16a34a';
-  const url = `https://img.shields.io/badge/${label}-${msg}-${color}?style=${BADGE_STYLE}`;
-  return `[![LSI · ${year===0?'Ingresante':year+'º año'}](${url})](${shareUrl()})`;
+  const year = highestYearWithProgress();
+  const files={
+    0:'1er-año.png',
+    1:'1er-año.png',
+    2:'2do-año.PNG',
+    3:'3er-año.PNG',
+    4:'4to-año.PNG',
+    5:'5to-año.PNG'
+  };
+  const file=files[year]||files[0];
+  const imgUrl=new URL('../assets/badges/'+file,location.href).href;
+  const alt=`LSI · ${year===0?'Ingresante':year+'º año'}`;
+  return `[![${alt}](${imgUrl})](${shareUrl()})`;
 }
 function makePctBadgeMarkdown(){
   const pct = computeLicPct();


### PR DESCRIPTION
## Summary
- Add `highestYearWithProgress` to determine most advanced year with any subject state
- Use active year instead of fully approved year when copying badge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0126056c832e8958525c50ccd6fb