### PR TITLE
Agregar nombre de estudiante al simulador

### DIFF
--- a/docs/estado.html
+++ b/docs/estado.html
@@ -32,6 +32,7 @@
   }
   .wrap{max-width:900px;margin:0 auto;padding:16px}
   h1{margin:0 0 16px;font-size:1.8rem}
+  .owner{font-family:Georgia,serif;color:#3b82f6}
   .panel{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:16px;margin-bottom:16px}
   .bar{display:flex;align-items:center;gap:10px;min-width:280px}
   .meter{height:10px;border-radius:999px;background:var(--panel);border:1px solid var(--border);overflow:hidden;flex:1}
@@ -81,7 +82,7 @@
 </head>
 <body>
 <div class="wrap">
-  <h1>Estado de carrera</h1>
+  <h1>Estado de carrera <span id="owner" class="owner"></span></h1>
   <div id="head" class="panel"></div>
   <div id="list" class="panel"></div>
 </div>
@@ -113,6 +114,7 @@ document.body.classList.add(savedTheme);
   }
   const share=decodeHash();
   if(!share){ document.getElementById('head').textContent='Sin datos.'; return; }
+  document.getElementById('owner').textContent = share.name || '';
   const plans = await (await fetch('plans.json')).json();
   const plan = plans[share.plan];
   if(!plan){ document.getElementById('head').textContent='Plan no encontrado.'; return; }

--- a/docs/simulador.html
+++ b/docs/simulador.html
@@ -206,6 +206,7 @@ padding:8px 12px;border-radius:12px;font-weight:600
     <h1>Simulador de Avance</h1>
     <div class="toolbar">
       <select id="plan"></select>
+      <input id="studentName" placeholder="Tu nombre">
       <input id="search" type="search" placeholder="Buscar materia..." />
       <details id="menu" class="menu">
         <summary>Opciones</summary>
@@ -312,7 +313,8 @@ window.addEventListener('resize', responsiveMenu);
 const savedTheme=localStorage.getItem('theme')||'theme-dark';
 document.body.classList.add(savedTheme);
 const STORAGE_KEY='simulador-avance';
-let plans={}, currentPlan='', states={};
+const NAME_KEY='simulador-nombre';
+let plans={}, currentPlan='', states={}, studentName='';
 
 const ANALISTA_OVERRIDES = {};
 
@@ -350,6 +352,7 @@ fetch('plans.json').then(r=>r.json()).then(data=>{
   sel.addEventListener('change',()=>{ currentPlan=sel.value; loadStates(); render(); });
   document.getElementById('search').addEventListener('input',render);
   document.getElementById('onlyEnabled').addEventListener('change',render);
+  document.getElementById('studentName').addEventListener('input',e=>{ studentName=e.target.value; saveStates(); });
   loadStates(); render();
 });
 
@@ -361,10 +364,13 @@ function loadStates(){
     if(typeof v==='object') states[c]=v;
     else states[c]={s:v,n:''};
   });
+  studentName=localStorage.getItem(NAME_KEY)||'';
+  document.getElementById('studentName').value=studentName;
 }
 function saveStates(){
   const all=JSON.parse(localStorage.getItem(STORAGE_KEY)||'{}');
   all[currentPlan]=states; localStorage.setItem(STORAGE_KEY,JSON.stringify(all));
+  localStorage.setItem(NAME_KEY,studentName);
 }
 function getStatus(code){
   const v=states[code];
@@ -560,7 +566,7 @@ function highestYearWithProgress(){
   return max;
 }
 function currentShareHash(){
-  const payload={ plan: currentPlan, states };
+  const payload={ plan: currentPlan, states, name: studentName };
   const json=JSON.stringify(payload);
   return btoa(unescape(encodeURIComponent(json)));
 }


### PR DESCRIPTION
## Summary
- Permite ingresar el nombre del estudiante y compartirlo en el enlace de estado
- Muestra el nombre en la página de estado con estilo destacado

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac08ec9bd8832e90e3bdd2c7aa3040